### PR TITLE
Fix `package.json` metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,24 @@
 {
   "name": "scrypt-kdf",
   "description": "Scrypt Key Derivation Function",
-  "keywords": "crypto scrypt kdf password hash login authenticate verify",
+  "keywords": [
+    "crypto",
+    "scrypt",
+    "kdf",
+    "password",
+    "hash",
+    "login",
+    "authenticate",
+    "verify"
+  ],
   "author": "Chris Veness",
   "repository": { "type": "git", "url": "https://github.com/chrisveness/scrypt-kdf" },
   "version": "1.0.1",
   "license": "MIT",
   "main": "scrypt.js",
-  "engineStrict": ">=10.5.0",
+  "engines": {
+    "node": ">=10.5.0"
+  },
   "scripts": {
     "test": "mocha --exit test/scrypt-tests.js",
     "lint": "eslint scrypt.js test/scrypt-tests.js",


### PR DESCRIPTION
This commit fixes issues with `package.json`. It replaces the no longer supported `engineStrict` field by `engines.node` and uses an array of strings for the keywords.