### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+
+language: node_js
+
+notifications:
+  email: false
+
+node_js:
+- "10"
+- "11"
+
+os:
+- linux
+- osx
+- windows

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build status](https://img.shields.io/travis/chrisveness/scrypt-kdf/master.svg?maxAge=2592000)](https://travis-ci.org/chrisveness/scrypt-kdf)
+
 Scrypt Key Derivation Function
 ==============================
 


### PR DESCRIPTION
This commit adds a Travis CI config file and badge. Integration still needs to be enabled manually.