### PR TITLE
Accept key as Uint8Array

### DIFF
--- a/scrypt.d.ts
+++ b/scrypt.d.ts
@@ -40,7 +40,7 @@ export declare function kdf(passphrase: string|ArrayBufferView, params: Readonly
  * @example
  *   const ok = await Scrypt.verify(key, 'my secret password');
  */
-export declare function verify(key: Buffer, passphrase: string|ArrayBufferView): Promise<boolean>;
+export declare function verify(key: Uint8Array, passphrase: string|ArrayBufferView): Promise<boolean>;
 
 /**
  * View scrypt parameters which were used to derive key.
@@ -52,7 +52,7 @@ export declare function verify(key: Buffer, passphrase: string|ArrayBufferView):
  *   const key = await Scrypt.kdf('my secret password', { logN: 15 } );
  *   const params = Scrypt.viewParams(key); // => { logN: 15, r: 8, p: 1 }
  */
-export declare function viewParams(key: string): ScryptParams;
+export declare function viewParams(key: Uint8Array): ScryptParams;
 
 /**
  * Calculate scrypt parameters from maxtime, maxmem, maxmemfrac values.

--- a/scrypt.js
+++ b/scrypt.js
@@ -112,7 +112,7 @@ class Scrypt {
     /**
      * Check whether key was generated from passphrase.
      *
-     * @param {Buffer} key - Derived key obtained from Scrypt.kdf().
+     * @param {Uint8Array|Buffer} key - Derived key obtained from Scrypt.kdf().
      * @param {string|TypedArray|Buffer} passphrase - Passphrase originally used to generate key.
      * @returns {Promise<boolean>} True if key was generated from passphrase.
      *
@@ -121,7 +121,7 @@ class Scrypt {
      *   const ok = await Scrypt.verify(Buffer.from(key, 'base64'), 'my secret password');
      */
     static async verify(key, passphrase) {
-        if (!(key instanceof Buffer)) throw new TypeError('Key must be a Buffer');
+        if (!(key instanceof Uint8Array)) throw new TypeError('Key must be a Buffer');
         if (key.length != 96) throw new RangeError('Invalid key');
         if (typeof passphrase!='string' && !ArrayBuffer.isView(passphrase)) throw new TypeError('Passphrase must be a string, TypedArray, or Buffer');
 
@@ -176,7 +176,7 @@ class Scrypt {
     /**
      * View scrypt parameters which were used to derive key.
      *
-     * @param {string} key - Derived base64 key obtained from Scrypt.kdf().
+     * @param {Uint8Array|Buffer} key - Derived base64 key obtained from Scrypt.kdf().
      * @returns {Object} Scrypt parameters logN, r, p.
      *
      * @example
@@ -184,7 +184,7 @@ class Scrypt {
      *   const params = Scrypt.viewParams(key); // => { logN: 15, r: 8, p: 1 }
      */
     static viewParams(key) {
-        if (!(key instanceof Buffer)) throw new TypeError('Key must be a Buffer');
+        if (!(key instanceof Uint8Array)) throw new TypeError('Key must be a Buffer');
         if (key.length != 96) throw new RangeError('Invalid key');
 
         // use the underlying ArrayBuffer to view key in structured format

--- a/test/scrypt-tests.js
+++ b/test/scrypt-tests.js
@@ -51,6 +51,24 @@ describe('Scrypt tests', function() {
         });
     });
 
+    describe('Uint8Array/Buffer key', function() {
+        this.slow(200); // kdf() is intentionally slow
+
+        it('Uint8Array', async function() {
+            const pwBuffer = Buffer.from([ 99, 98, 97, 96, 95, 94, 94, 92, 91 ]);
+            const keyTypedArray = new Uint8Array(await Scrypt.kdf(pwBuffer, { logN: 12 }));
+            expect(Scrypt.viewParams(keyTypedArray)).to.deep.equal({ logN: 12, r: 8, p: 1 });
+            expect(await Scrypt.verify(keyTypedArray, pwBuffer)).to.be.true;
+        });
+
+        it('Buffer', async function() {
+            const pwBuffer = Buffer.from([ 99, 98, 97, 96, 95, 94, 94, 92, 91 ]);
+            const keyBuffer = await Scrypt.kdf(pwBuffer, { logN: 12 });
+            expect(Scrypt.viewParams(keyBuffer)).to.deep.equal({ logN: 12, r: 8, p: 1 });
+            expect(await Scrypt.verify(keyBuffer, pwBuffer)).to.be.true;
+        });
+    });
+
     describe('TypedArray/Buffer passphrase', function() {
         this.slow(200); // kdf() is intentionally slow
 


### PR DESCRIPTION
This commit weakens the constraint on the key: it can be a simple `TypedArray` (e.g. `Uint8Array`) instead of requiring a `Buffer`. This aligns the preconditions with the actual usage inside the functions.
This commit also fixes the type definition for `viewParams` (which was still marked as accepting a `string`).