### PR TITLE
Allow Node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "scrypt.js",
   "types": "scrypt.d.ts",
   "engines": {
-    "node": ">=10.5.0"
+    "node": ">=8.5.0"
   },
   "scripts": {
     "test": "mocha --exit test/scrypt-tests.js",


### PR DESCRIPTION
README states that

> if you want to use it with Node.js < 10.5.0, you can polyfill the OpenSSL scrypt with scrypt-async

So package.json `engines` field should allow this.